### PR TITLE
Remove unused LinkingTo: entry from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
 Depends:
     scales, RColorBrewer
 LinkingTo: 
-    cpp11,
     Rcpp,
     RcppArmadillo,
     RcppProgress


### PR DESCRIPTION
The package declares LinkingTo of several packages, which was intriguing but on closer look it appears that one of those (cpp11) is not actually used by the source files and can be removed. This was verified this in a local build, and CI should confirm it here once you trigger it.

This is obviously not the most important thing in the world but it will for example make your continuous integration tests marginally faster as it involves one less package.  Feel free to ignore this and close it if you have other reasons to keep the package.